### PR TITLE
fix(loader): add explicit export for webpack loader resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dataroadinc/rdf-loader",
-    "version": "0.0.4",
+    "version": "0.0.1",
     "description": "A webpack loader for importing RDF files directly as JavaScript modules",
     "type": "module",
     "main": "dist/index.js",
@@ -14,6 +14,9 @@
         "./loader": {
             "import": "./dist/index.js",
             "types": "./dist/index.d.ts"
+        },
+        "./dist/index.js": {
+            "import": "./dist/index.js"
         }
     },
     "files": [


### PR DESCRIPTION
- Add explicit export for './dist/index.js' to fix webpack loader resolution
- Update version to 0.0.1 for stateless versioning
- Fixes 'Package path . is not exported' error in ESM environments